### PR TITLE
PolarReader NamespacedID remove block state data

### DIFF
--- a/src/main/java/net/hollowcube/polar/PolarReader.java
+++ b/src/main/java/net/hollowcube/polar/PolarReader.java
@@ -92,7 +92,8 @@ public class PolarReader {
         var blockPalette = buffer.readCollection(STRING).toArray(String[]::new);
         if (version <= PolarWorld.VERSION_SHORT_GRASS) {
             for (int i = 0; i < blockPalette.length; i++) {
-                if (NamespaceID.from(blockPalette[i]).path().equals("grass"))
+                String strippedID = blockPalette[i].split("\\[")[0];
+                if (NamespaceID.from(strippedID).path().equals("grass"))
                     blockPalette[i] = "short_grass";
             }
         }


### PR DESCRIPTION
Hi,

I'm not sure if anyone else is experiencing this issue related to change #27.

When running in debug mode, the [assertion ](https://github.com/Minestom/Minestom/blob/2cdb3911b0081770621af5e0cb2c0e0299bd0a5f/src/main/java/net/minestom/server/utils/NamespaceID.java#L55)in minestom/minestom-ce's NamespacedID is triggered when blocks with block states are passed into NamespacedID.from().

E.g. when reading blockPalette[i] with value 'grass_block[snowy=false]', the assertion illegal path is triggered because "[" and "]" are not accepted characters.

I have patched the issue by removing any blockstate data before passing to NamespacedID.

Hope this helps,
Mac