### PR TITLE
Defer namespaceid call to prevent memory explosion

### DIFF
--- a/src/main/java/net/hollowcube/polar/PolarReader.java
+++ b/src/main/java/net/hollowcube/polar/PolarReader.java
@@ -116,9 +116,12 @@ public class PolarReader {
         }
         if (version <= PolarWorld.VERSION_SHORT_GRASS) {
             for (int i = 0; i < blockPalette.length; i++) {
-                String strippedID = blockPalette[i].split("\\[")[0];
-                if (NamespaceID.from(strippedID).path().equals("grass"))
-                    blockPalette[i] = "short_grass";
+                if (blockPalette[i].contains("grass")) {
+                    String strippedID = blockPalette[i].split("\\[")[0];
+                    if (NamespaceID.from(strippedID).path().equals("grass")) {
+                        blockPalette[i] = "short_grass";
+                    }
+                }
             }
         }
         int[] blockData = null;


### PR DESCRIPTION
Not sure what the interaction here is, I guess the cache keeping around every variation of NSID which is tested (probably should have a cap). In the case tested this caused >1gb of allocations pre change, around 40mb after.

Probably I need to look further into this in Minestom, but its fixed here for now.