### PR TITLE
Streaming loader

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 metadata.format.version = "1.1"
 
 [versions]
-minestom = "1_21_2-63fb5bf72b"
+minestom = "d760a60a5c"
 zstd = "1.5.5-3"
 fastutil = "8.5.12"
 

--- a/src/main/java/net/hollowcube/polar/NetworkBufferAccess.java
+++ b/src/main/java/net/hollowcube/polar/NetworkBufferAccess.java
@@ -1,0 +1,7 @@
+package net.hollowcube.polar;
+
+/**
+ * Provides access to some internals of NetworkBuffer to avoid copying data in some cases.
+ */
+final class NetworkBufferAccess {
+}

--- a/src/main/java/net/hollowcube/polar/NetworkBufferAccess.java
+++ b/src/main/java/net/hollowcube/polar/NetworkBufferAccess.java
@@ -1,7 +1,0 @@
-package net.hollowcube.polar;
-
-/**
- * Provides access to some internals of NetworkBuffer to avoid copying data in some cases.
- */
-final class NetworkBufferAccess {
-}

--- a/src/main/java/net/hollowcube/polar/PolarWorldAccess.java
+++ b/src/main/java/net/hollowcube/polar/PolarWorldAccess.java
@@ -17,7 +17,6 @@ import org.jetbrains.annotations.Nullable;
  * Usage if world access is completely optional, dependent features will not add
  * overhead to the format if unused.
  */
-@SuppressWarnings("UnstableApiUsage")
 public interface PolarWorldAccess {
     PolarWorldAccess DEFAULT = new PolarWorldAccess() {
     };

--- a/src/main/java/net/hollowcube/polar/StreamingPolarLoader.java
+++ b/src/main/java/net/hollowcube/polar/StreamingPolarLoader.java
@@ -1,0 +1,298 @@
+package net.hollowcube.polar;
+
+import com.github.luben.zstd.Zstd;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.command.builder.arguments.minecraft.ArgumentBlockState;
+import net.minestom.server.command.builder.exception.ArgumentSyntaxException;
+import net.minestom.server.coordinate.CoordConversion;
+import net.minestom.server.instance.Chunk;
+import net.minestom.server.instance.InstanceContainer;
+import net.minestom.server.instance.Section;
+import net.minestom.server.network.NetworkBuffer;
+import net.minestom.server.utils.validate.Check;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.channels.ReadableByteChannel;
+import java.util.Objects;
+
+import static net.hollowcube.polar.PolarLoader.*;
+import static net.hollowcube.polar.PolarReader.*;
+import static net.hollowcube.polar.UnsafeOps.*;
+import static net.minestom.server.instance.palette.PolarPaletteAccessWidener.directReplaceInnerPaletteBiome;
+import static net.minestom.server.instance.palette.PolarPaletteAccessWidener.directReplaceInnerPaletteBlock;
+import static net.minestom.server.network.NetworkBuffer.*;
+import static net.minestom.server.network.PolarBufferAccessWidener.networkBufferAddress;
+import static net.minestom.server.network.PolarBufferAccessWidener.networkBufferView;
+
+final class StreamingPolarLoader {
+    private final InstanceContainer instance;
+    private final PolarDataConverter dataConverter;
+    private final PolarWorldAccess worldAccess;
+    private final boolean loadLighting;
+
+    private int version, dataVersion;
+
+    private final Object2IntMap<String> blockToStateIdCache = new Object2IntOpenHashMap<>();
+    private final Object2IntMap<String> biomeToIdCache = new Object2IntOpenHashMap<>();
+
+    StreamingPolarLoader(@NotNull InstanceContainer instance, @NotNull PolarDataConverter dataConverter,
+                         @Nullable PolarWorldAccess worldAccess, boolean loadLighting) {
+        this.instance = instance;
+        this.dataConverter = dataConverter;
+        this.worldAccess = worldAccess;
+        this.loadLighting = loadLighting;
+    }
+
+    public void loadAllSequential(@NotNull ReadableByteChannel channel, long fileSize) throws IOException {
+        final var buffer = readHeader(channel, fileSize);
+
+        byte minSection = buffer.read(BYTE), maxSection = buffer.read(BYTE);
+        assertThat(minSection < maxSection, "Invalid section range");
+
+        // User (world) data
+        if (version > PolarWorld.VERSION_WORLD_USERDATA) {
+            int userDataLength = buffer.read(VAR_INT);
+            if (worldAccess != null) {
+                var worldDataView = networkBufferView(buffer, buffer.readIndex(), userDataLength);
+                worldAccess.loadWorldData(instance, worldDataView);
+            }
+            buffer.advanceRead(userDataLength);
+        }
+
+        // Chunk data
+        int chunkCount = buffer.read(VAR_INT);
+        for (int i = 0; i < chunkCount; i++) {
+            unsafeCacheChunk(instance, readChunk(buffer, minSection, maxSection));
+        }
+
+        Check.stateCondition(buffer.readableBytes() > 0, "Unexpected extra data at end of buffer");
+    }
+
+    /**
+     * Reads the header and returns a network buffer containing the decompressed content.
+     *
+     * <p>Always populates {@link #version} and {@link #dataVersion}.</p>
+     */
+    private NetworkBuffer readHeader(@NotNull ReadableByteChannel channel, long fileSize) throws IOException {
+        final var buffer = NetworkBuffer.staticBuffer(fileSize, MinecraftServer.process());
+        buffer.readChannel(channel);
+
+        var magicNumber = buffer.read(INT);
+        assertThat(magicNumber == PolarWorld.MAGIC_NUMBER, "Invalid magic number");
+
+        this.version = buffer.read(SHORT);
+        validateVersion(this.version);
+        this.dataVersion = version >= PolarWorld.VERSION_DATA_CONVERTER
+                ? buffer.read(VAR_INT)
+                : dataConverter.defaultDataVersion();
+
+        var compression = PolarWorld.CompressionType.fromId(buffer.read(BYTE));
+        assertThat(compression != null, "Invalid compression type");
+        var compressedDataLength = buffer.read(VAR_INT);
+
+        return switch (compression) {
+            case NONE -> buffer;
+            case ZSTD -> {
+                // This is using some internals of Minestom, so worth an explanation. As of 1.21.3, network buffer is
+                // backed by a directly allocated array via Unsafe. Zstd supports direct decompression, so we can use
+                // the direct addresses of the two buffers for decompression.
+                final var dst = NetworkBuffer.staticBuffer(compressedDataLength, MinecraftServer.process());
+                final var srcAddress = networkBufferAddress(buffer) + buffer.readIndex();
+                final var dstAddress = networkBufferAddress(dst);
+                long count = Zstd.decompressUnsafe(dstAddress, compressedDataLength, srcAddress, buffer.readableBytes());
+                if (Zstd.isError(count)) {
+                    throw new RuntimeException("decompression failed: " + Zstd.getErrorName(count));
+                }
+                dst.writeIndex(compressedDataLength);
+                yield dst;
+                // The original buffer is useless and may be collected at this point.
+            }
+        };
+    }
+
+    private @NotNull Chunk readChunk(@NotNull NetworkBuffer buffer, int minSection, int maxSection) {
+        final var chunkX = buffer.read(VAR_INT);
+        final var chunkZ = buffer.read(VAR_INT);
+        final var chunk = instance.getChunkSupplier().createChunk(instance, chunkX, chunkZ);
+        unsafeSetNeedsCompleteHeightmapRefresh(chunk, false);
+        var chunkEntries = unsafeGetEntries(chunk);
+        var chunkTickables = unsafeGetTickableMap(chunk);
+
+        // Load block data
+        synchronized (chunk) {
+            for (int sectionY = minSection; sectionY <= maxSection; sectionY++) {
+                readSection(buffer, chunk.getSection(sectionY));
+            }
+
+            // Load block entities
+            final int blockEntityCount = buffer.read(VAR_INT);
+            for (int i = 0; i < blockEntityCount; i++) {
+                final var blockEntity = readBlockEntity(dataConverter, version, dataVersion, buffer);
+                if (chunkEntries != null && chunkTickables != null) {
+                    final var block = createBlockEntity(chunk, blockEntity);
+                    final int index = CoordConversion.chunkBlockIndex(blockEntity.x(), blockEntity.y(), blockEntity.z());
+                    chunkEntries.put(index, block);
+                    if (block.handler() != null && block.handler().isTickable())
+                        chunkTickables.put(index, block);
+                } else {
+                    loadBlockEntity(chunk, blockEntity);
+                }
+            }
+
+            // Load heightmaps (if we have world data, otherwise we can skip)
+            int[][] heightmaps = readHeightmapData(buffer, worldAccess == null);
+            if (worldAccess != null) worldAccess.loadHeightmaps(chunk, heightmaps);
+            else unsafeSetNeedsCompleteHeightmapRefresh(chunk, true);
+
+            // Load user data
+            if (version > PolarWorld.VERSION_USERDATA_OPT_BLOCK_ENT_NBT) {
+                int userDataLength = buffer.read(VAR_INT);
+                if (worldAccess != null) {
+                    var chunkDataView = networkBufferView(buffer, buffer.readIndex(), userDataLength);
+                    worldAccess.loadChunkData(chunk, chunkDataView);
+                }
+                buffer.advanceRead(userDataLength);
+            }
+        }
+
+        return chunk;
+    }
+
+    private void readSection(@NotNull NetworkBuffer buffer, @NotNull Section section) {
+        if (buffer.read(BOOLEAN)) return; // Empty section
+
+        int[] blockPalette = readBlockPalette(buffer);
+        if (blockPalette.length == 1) {
+            // We just created the palette, no need to set air blocks.
+            if (blockPalette[0] != 0) {
+                section.blockPalette().fill(blockPalette[0]);
+            }
+        } else {
+            var rawBlockData = buffer.read(LONG_ARRAY);
+            var bitsPerEntry = (int) Math.ceil(Math.log(blockPalette.length) / Math.log(2));
+
+            int count = computeCount(blockPalette, rawBlockData, bitsPerEntry);
+            directReplaceInnerPaletteBlock(section.blockPalette(), (byte) bitsPerEntry, count,
+                    blockPalette, rawBlockData);
+        }
+
+        int[] biomePalette = readBiomePalette(buffer);
+        if (biomePalette.length == 1) {
+            section.biomePalette().fill(biomePalette[0]);
+        } else {
+            var rawBiomeData = buffer.read(LONG_ARRAY);
+            var bitsPerEntry = (int) Math.ceil(Math.log(biomePalette.length) / Math.log(2));
+            // Biome count is irrelevant to the client. Though it might be worth computing it anyway here
+            // in case a server implementation uses it for anything.
+            directReplaceInnerPaletteBiome(section.biomePalette(), (byte) bitsPerEntry, 4 * 4 * 4,
+                    biomePalette, rawBiomeData);
+        }
+
+        if (version > PolarWorld.VERSION_UNIFIED_LIGHT) {
+            var blockLightContent = version >= PolarWorld.VERSION_IMPROVED_LIGHT
+                    ? PolarSection.LightContent.VALUES[buffer.read(BYTE)]
+                    : (buffer.read(BOOLEAN) ? PolarSection.LightContent.PRESENT : PolarSection.LightContent.MISSING);
+            byte[] blockLight = blockLightContent == PolarSection.LightContent.PRESENT ? buffer.read(LIGHT_DATA) : null;
+            if (loadLighting && blockLightContent != PolarSection.LightContent.MISSING)
+                section.setBlockLight(getLightArray(blockLightContent, blockLight));
+
+            var skyLightContent = version >= PolarWorld.VERSION_IMPROVED_LIGHT
+                    ? PolarSection.LightContent.VALUES[buffer.read(BYTE)]
+                    : (buffer.read(BOOLEAN) ? PolarSection.LightContent.PRESENT : PolarSection.LightContent.MISSING);
+            byte[] skyLight = skyLightContent == PolarSection.LightContent.PRESENT ? buffer.read(LIGHT_DATA) : null;
+            if (loadLighting && skyLightContent != PolarSection.LightContent.MISSING)
+                section.setSkyLight(getLightArray(skyLightContent, skyLight));
+        } else if (buffer.read(BOOLEAN)) {
+            if (loadLighting) {
+                section.setBlockLight(buffer.read(LIGHT_DATA));
+                section.setSkyLight(buffer.read(LIGHT_DATA));
+            } else {
+                buffer.advanceRead(2048 * 2); // Skip the data
+            }
+        }
+    }
+
+    private int[] readBlockPalette(@NotNull NetworkBuffer buffer) {
+        var rawBlockPalette = buffer.read(STRING_ARRAY);
+        if (dataVersion < dataConverter.dataVersion()) {
+            dataConverter.convertBlockPalette(rawBlockPalette, dataVersion, dataConverter.dataVersion());
+        }
+        upgradeGrassInPalette(rawBlockPalette, version);
+        int[] blockPalette = new int[rawBlockPalette.length];
+        for (int i = 0; i < rawBlockPalette.length; i++) {
+            blockPalette[i] = blockToStateIdCache.computeIfAbsent(rawBlockPalette[i], (String key) -> {
+                try {
+                    //noinspection deprecation
+                    return ArgumentBlockState.staticParse(key).stateId();
+                } catch (ArgumentSyntaxException e) {
+                    throw new RuntimeException("Failed to parse block state: " + key, e);
+                }
+            });
+        }
+        return blockPalette;
+    }
+
+    private int[] readBiomePalette(@NotNull NetworkBuffer buffer) {
+        var rawBiomePalette = buffer.read(STRING_ARRAY);
+        int[] biomePalette = new int[rawBiomePalette.length];
+        for (int i = 0; i < rawBiomePalette.length; i++) {
+            biomePalette[i] = biomeToIdCache.computeIfAbsent(rawBiomePalette[i], (String name) -> {
+                PolarWorldAccess worldAccess = Objects.requireNonNullElse(this.worldAccess, PolarWorldAccess.DEFAULT);
+                var biomeId = BIOME_REGISTRY.getId(worldAccess.getBiome(name));
+                if (biomeId == -1) {
+                    logger.error("Failed to find biome: {}", name);
+                    biomeId = PLAINS_BIOME_ID;
+                }
+                return biomeId;
+            });
+        }
+        return biomePalette;
+    }
+
+    private int computeCount(int[] palette, long[] rawData, int bitsPerEntry) {
+        int zeroIndex = -1;
+        for (int i = 0; i < palette.length; i++) {
+            if (palette[i] == 0) {
+                zeroIndex = i;
+                break;
+            }
+        }
+
+        int count = 0;
+        var intsPerLong = Math.floor(64d / bitsPerEntry);
+        var intsPerLongCeil = (int) Math.ceil(intsPerLong);
+        long mask = (1L << bitsPerEntry) - 1L;
+        for (int i = 0; i < PolarSection.BLOCK_PALETTE_SIZE; i++) {
+            int longIndex = i / intsPerLongCeil;
+            int subIndex = i % intsPerLongCeil;
+
+            int index = (int) ((rawData[longIndex] >>> (bitsPerEntry * subIndex)) & mask);
+            if (index != zeroIndex) {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static final NetworkBuffer.Type<String[]> STRING_ARRAY = new NetworkBuffer.Type<>() {
+
+        @Override
+        public void write(@NotNull NetworkBuffer buffer, String[] value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String[] read(@NotNull NetworkBuffer buffer) {
+            final String[] array = new String[buffer.read(VAR_INT)];
+            for (int i = 0; i < array.length; i++) {
+                array[i] = buffer.read(STRING);
+            }
+            return array;
+        }
+    };
+}

--- a/src/main/java/net/hollowcube/polar/UnsafeOps.java
+++ b/src/main/java/net/hollowcube/polar/UnsafeOps.java
@@ -1,0 +1,79 @@
+package net.hollowcube.polar;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import net.minestom.server.instance.Chunk;
+import net.minestom.server.instance.DynamicChunk;
+import net.minestom.server.instance.InstanceContainer;
+import net.minestom.server.instance.block.Block;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
+final class UnsafeOps {
+    private static final MethodHandle CACHE_CHUNK_HANDLE;
+    private static final MethodHandle NEEDS_HEIGHTMAP_REFRESH_SETTER;
+    private static final MethodHandle DYNAMIC_CHUNK_ENTRIES_GETTER;
+    private static final MethodHandle DYNAMIC_CHUNK_TICKABLE_MAP_GETTER;
+
+    static void unsafeCacheChunk(@NotNull InstanceContainer instance, @NotNull Chunk chunk) {
+        try {
+            CACHE_CHUNK_HANDLE.invokeExact(instance, chunk);
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    static void unsafeSetNeedsCompleteHeightmapRefresh(@NotNull Chunk chunk, boolean value) {
+        if (chunk instanceof DynamicChunk dynamicChunk) {
+            try {
+                NEEDS_HEIGHTMAP_REFRESH_SETTER.invokeExact(dynamicChunk, value);
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+        }
+    }
+
+    static @Nullable Int2ObjectOpenHashMap<Block> unsafeGetEntries(@NotNull Chunk chunk) {
+        if (chunk instanceof DynamicChunk dynamicChunk) {
+            try {
+                return (Int2ObjectOpenHashMap<Block>) DYNAMIC_CHUNK_ENTRIES_GETTER.invokeExact(dynamicChunk);
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+        } else return null;
+    }
+
+    static @Nullable Int2ObjectOpenHashMap<Block> unsafeGetTickableMap(@NotNull Chunk chunk) {
+        if (chunk instanceof DynamicChunk dynamicChunk) {
+            try {
+                return (Int2ObjectOpenHashMap<Block>) DYNAMIC_CHUNK_TICKABLE_MAP_GETTER.invokeExact(dynamicChunk);
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+        } else return null;
+    }
+
+    static {
+        try {
+            var lookup = MethodHandles.privateLookupIn(InstanceContainer.class, MethodHandles.lookup());
+            var method = InstanceContainer.class.getDeclaredMethod("cacheChunk", Chunk.class);
+            CACHE_CHUNK_HANDLE = lookup.unreflect(method);
+        } catch (IllegalAccessException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+
+        try {
+            var lookup = MethodHandles.privateLookupIn(DynamicChunk.class, MethodHandles.lookup());
+            NEEDS_HEIGHTMAP_REFRESH_SETTER = lookup.unreflectSetter(DynamicChunk.class
+                    .getDeclaredField("needsCompleteHeightmapRefresh"));
+            DYNAMIC_CHUNK_ENTRIES_GETTER = lookup.unreflectGetter(DynamicChunk.class
+                    .getDeclaredField("entries"));
+            DYNAMIC_CHUNK_TICKABLE_MAP_GETTER = lookup.unreflectGetter(DynamicChunk.class
+                    .getDeclaredField("tickableMap"));
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/net/minestom/server/instance/palette/PolarPaletteAccessWidener.java
+++ b/src/main/java/net/minestom/server/instance/palette/PolarPaletteAccessWidener.java
@@ -1,0 +1,30 @@
+package net.minestom.server.instance.palette;
+
+import org.jetbrains.annotations.NotNull;
+
+public final class PolarPaletteAccessWidener {
+
+    public static void directReplaceInnerPaletteBlock(
+            @NotNull Palette outer, byte bitsPerEntry,
+            int count, int[] palette, long[] values) {
+        directReplaceInnerPalette(outer, 16, 8, bitsPerEntry, count, palette, values);
+    }
+
+    public static void directReplaceInnerPaletteBiome(
+            @NotNull Palette outer, byte bitsPerEntry,
+            int count, int[] palette, long[] values) {
+        directReplaceInnerPalette(outer, 4, 3, bitsPerEntry, count, palette, values);
+    }
+
+    public static void directReplaceInnerPalette(
+            @NotNull Palette outer,
+            int dimension, int maxBitsPerEntry, byte bitsPerEntry,
+            int count, int[] palette, long[] values) {
+        if (!(outer instanceof AdaptivePalette adaptive))
+            throw new IllegalArgumentException("Cannot replace inner palette of non-adaptive palette");
+        var inner = new PaletteIndirect(dimension, maxBitsPerEntry, bitsPerEntry, count, palette, values);
+        inner.values = values; // Minestom accidentally overwrites the passed values. That is wrong.
+        adaptive.palette = inner;
+    }
+
+}

--- a/src/main/java/net/minestom/server/network/PolarBufferAccessWidener.java
+++ b/src/main/java/net/minestom/server/network/PolarBufferAccessWidener.java
@@ -1,0 +1,60 @@
+package net.minestom.server.network;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
+import static net.minestom.server.network.NetworkBufferImpl.impl;
+
+/**
+ * Provides some low level access to the internals of {@link NetworkBuffer}.
+ *
+ * <p><b>Do not use this class.</b></p>
+ */
+@ApiStatus.Internal
+public final class PolarBufferAccessWidener {
+    private static final MethodHandle ADDRESS_GETTER;
+    private static final MethodHandle ADDRESS_SETTER;
+
+    public static @NotNull NetworkBuffer networkBufferView(@NotNull NetworkBuffer buffer, long start, long length) {
+        // We create the buffer with -1 to indicate its a 'dummy' buffer. We do not want to cleaner attached to
+        // this buffer to free the backing data. We will later update the address.
+        var viewBuffer = new NetworkBufferImpl(-1, length, 0, 0, null, impl(buffer).registries);
+        setAddress(impl(viewBuffer), getAddress(impl(buffer)) + start);
+        viewBuffer.readOnly();
+        return viewBuffer;
+    }
+
+    public static long networkBufferAddress(@NotNull NetworkBuffer buffer) {
+        return getAddress(impl(buffer));
+    }
+
+    private static long getAddress(@NotNull NetworkBufferImpl impl) {
+        try {
+            return (long) ADDRESS_GETTER.invokeExact(impl);
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    private static void setAddress(@NotNull NetworkBufferImpl impl, long address) {
+        try {
+            ADDRESS_SETTER.invokeExact(impl, address);
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    static {
+        try {
+            final var lookup = MethodHandles.privateLookupIn(NetworkBufferImpl.class, MethodHandles.lookup());
+            final var field = NetworkBufferImpl.class.getDeclaredField("address");
+            ADDRESS_GETTER = lookup.unreflectGetter(field);
+            ADDRESS_SETTER = lookup.unreflectSetter(field);
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Adds a streaming world loader. Lots of discussion following :)

### Problem

There is a general inefficiency with loading Polar worlds currently, say you load a world similar to the following:

```java
var instance = new InstanceContainer(UUID.randomUUID(), DimensionType.OVERWORLD);

var mapData = Files.readAllBytes(WORLD_FILE);
var loader = new PolarLoader(PolarReader.read(mapData));
instance.setChunkLoader(loader);

loader.loadInstance(instance);

var loadingChunks = new ArrayList<CompletableFuture<Chunk>>();
loader.world().chunks().forEach(chunk -> loadingChunks.add(instance.loadChunk(chunk.x(), chunk.z())));
CompletableFuture.allOf(loadingChunks.toArray(CompletableFuture[]::new)).join();
```

What you may not initially consider here is that you end up storing multiple copies of the world data.
1. `mapData` containing the compressed raw data
2. `loader.world` has the `PolarWorld` instance which has java representations of the loaded world. Most notably, this contains unpacked block data (eg `int[4096]`s) for each section (!).
3. The Minestom `Chunk` objects (really most of the data is in `Section`s).

You could improve this long term by replacing the chunk loader with a different one, eg `instance.setChunkLoader(IChunkLoader.noop())` at the end. This improves the situation long term (we only store the copy of the world in the Minestom chunk objects). However, this solution still pays for the big memory spike while actually loading the world. If that all seems unnecessary, I agree! It also creates a non-zero amount of extra work to conform with existing APIs, for example we read palette data, expand it to use Palette#setAll, which then packs it back into a long array (there might be a larger discussion around Minestoms API here, but that is ignored for now).

### Presented Solution
The alternative approach given in this PR is to skip the intermediate PolarWorld struct entirely and create Minestom objects directly as we process the world file. This knocks the allocations down to simply the decompressed world data and the cost to instantiate all of the relevant Minestom objects (plus a little more for intermediate state.

Based on my _extremely_ rough experimentation, the streaming loader is ~10x faster and allocates ~30% of the memory when compared to the above example. You should do your own benchmarking depending in your target environment.

Optimizations requiring format changes (not sure if any are worth):
- Store the palette count to avoid having to compute it on load.
- Store the block state IDs for the current version allowing us to skip string parsing when the world is already on the current version (this would notably increase world sizes).