### PR TITLE
Fix to biome palette issue

### DIFF
--- a/src/main/java/net/hollowcube/polar/PolarLoader.java
+++ b/src/main/java/net/hollowcube/polar/PolarLoader.java
@@ -251,10 +251,10 @@ public class PolarLoader implements IChunkLoader {
             section.biomePalette().fill(biomePalette[0]);
         } else {
             final var paletteData = sectionData.biomeData();
-            for (int y = 0; y < CHUNK_SECTION_SIZE; y++) {
-                for (int z = 0; z < CHUNK_SECTION_SIZE; z++) {
-                    for (int x = 0; x < CHUNK_SECTION_SIZE; x++) {
-                        int index = x / 4 + (z / 4) * 4 + (y / 4) * 16;
+            for (int y = 0; y < CHUNK_SECTION_SIZE/4; y++) {
+                for (int z = 0; z < CHUNK_SECTION_SIZE/4; z++) {
+                    for (int x = 0; x < CHUNK_SECTION_SIZE/4; x++) {
+                        int index = x + (z) * 4 + (y) * 16;
 
                         var paletteIndex = paletteData[index];
                         if (paletteIndex >= biomePalette.length) {


### PR DESCRIPTION
Fixes #69 

Iterate the dimension size of the biome palette (4) instead of the block dimension of a chunk section (16).

See #69 for more info.